### PR TITLE
Fixing redirect for languages/subdomains that don't exist

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,6 +8,7 @@ RewriteBase /
 # and it will serve the index-fr.html file, so we have 
 # localisation
 RewriteCond %{HTTP_HOST} ^([^.]+)\.confcodeofconduct\.com$ [NC]
+RewriteCond index-%1.html -f
 RewriteRule ^index.html$ /index-%1.html
 
 </IfModule>


### PR DESCRIPTION
Going to a subdomain that doesn't exist (valid language code or otherwise) presents the visitor with a 404. Fixing the .htaccess to only use the language-specific file where it exists.
