### PR TITLE
Make spelling consistently American.

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ em {
 
 <h2>The Quick Version</h2>
 
-<p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
+<p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organizers.</p>
 
 <h2>The Less Quick Version</h2>
 


### PR DESCRIPTION
Organizers is spelled both with an 's' and with a 'z'. To make it consistent with the rest of the doc, use all 'z's.
