### PR TITLE
[Dutch] Translate page title and fix h1 translation

### DIFF
--- a/index-nl.html
+++ b/index-nl.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf8">
-<title>Conference Code of Conduct</title>
+<title>Gedragcode voor conferenties</title>
 <style>
 * { 
   font-family: 'helvetica neue', arial, helveica;
@@ -55,7 +55,7 @@ em {
 </style>
 </head>
 <body>
-<h1>Gedragscode</h1>
+<h1>Gedragscode voor conferenties</h1>
 
 <p>Alle deelnemers, sprekers, sponsoren en vrijwilligers op onze conferentie zijn verplicht zich te houden aan de volgende gedragscode. De organisatoren zullen hier de gehele conferentie op toezien. We verwachten dat iedereen meewerkt aan een veilige omgeving voor elkaar.</p>
 


### PR DESCRIPTION
The page title was untranslated and the h1 had all its context stripped upon translation.
