### PR TITLE
[Dutch] Fix Germanification of noun

### DIFF
--- a/index-nl.html
+++ b/index-nl.html
@@ -59,7 +59,7 @@ em {
 
 <p>Alle deelnemers, sprekers, sponsoren en vrijwilligers op onze conferentie zijn verplicht zich te houden aan de volgende gedragscode. De organisatoren zullen hier de gehele conferentie op toezien. We verwachten dat iedereen meewerkt aan een veilige omgeving voor elkaar.</p>
 
-<p><em>tl;dr: Wees geen Eikel</em></p>
+<p><em>tl;dr: Wees geen eikel</em></p>
 
 <h2>Hulp nodig?</h2>
 


### PR DESCRIPTION
Dutch does not capitalize nouns like German does.
