### PR TITLE
[Dutch] More accurate and widely used wording.

### DIFF
--- a/index-nl.html
+++ b/index-nl.html
@@ -67,7 +67,7 @@ em {
 
 <h2>De korte versie</h2>
 
-<p>Het is de conferentie aangelegen om iedereen een conferentie ervaring aan te bieden waarin niemand lastig wordt gevallen, ongeacht geslacht, seksuele ori&euml;ntatie, handicap, uiterlijk, lichaamsgrootte, ras of geloof. Intimidatie van deelnemers aan de conferentie wordt in geen enkele vorm getolereerd. Seksuele taal of beeld is niet gepast gedurende de conferentie activiteiten zoals praatjes, workshops, feestjes, Twitter of andere sociale media. Wanneer een deelnemer de gedragscode overtreedt mag het organiserend comit&eacute; optreden en de deelnemer <em>zonder schadeloosstelling</em> de toegang tot de conferentie ontzeggen.</p>
+<p>Het is de conferentie aangelegen om iedereen een conferentie ervaring aan te bieden waarin niemand lastig wordt gevallen, ongeacht geslacht, seksuele ori&euml;ntatie, handicap, uiterlijk, lichaamsgrootte, ras of geloof. Intimidatie van deelnemers aan de conferentie wordt in geen enkele vorm getolereerd. Seksuele taal of beeld is niet gepast gedurende de conferentie activiteiten zoals praatjes, workshops, feestjes, Twitter of andere sociale media. Wanneer een deelnemer de gedragscode overtreedt mag het organiserend comit&eacute; optreden en de deelnemer <em>zonder vergoeding</em> de toegang tot de conferentie ontzeggen.</p>
 
 <h2>De minder korte versie</h2>
 


### PR DESCRIPTION
"schadeloosstelling" implies damage, and is a word that is almost exclusively used in the insurance sector. "vergoeding" seems less specific and more familiar to mere mortals.
