### PR TITLE
Clarify and strengthen language Closes #51.

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ em {
 <body>
 <h1>Conference Code of Conduct</h1>
 
-<p>All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organisers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
+<p>All attendees, speakers, sponsors and volunteers at our conference are required to follow the following code of conduct. Organisers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
 
 <p><em>tl;dr: Be excellent with each other</em></p>
 
@@ -75,17 +75,17 @@ em {
 
 <h2>The Quick Version</h2>
 
-<p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, age, sexual orientation, disability, physical appearance, body size, race, or religion (or lack thereof). We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
+<p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, age, sexual orientation, disability, physical appearance, body size, race, or religion (or lack thereof). We do not tolerate abuse of conference participants in any form. Off-topic sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
 
 <h2>The Less Quick Version</h2>
 
-<p>Harassment includes offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+<p>Harassment includes physical violence, inappropriate physical contact, threats of physical harm, unwelcome sexual attention, deliberate intimidation, stalking, following, unwelcome violations of privacy including photography or recording, needless and offensive verbal comments, sustained disruption of talks or other events, and off-topic sexual images in public spaces.</p>
 
-<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+<p>Participants asked to stop any abuse are expected to comply immediately.</p>
 
-<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
+<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use off-topic sexual images, activities, or other material. Booth staff (including volunteers) should not use sexual clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
 
-<p>If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
+<p>If a participant abuses people, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
 
 <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they&#39;ll be wearing branded t-shirts.</p>
 


### PR DESCRIPTION
I intended to make the policy clearer on certain details and use more
powerful language. I also made certain parts of the policy focus more
on actions than intent because actions are a more concrete, less
ambiguous, and less abusable type of language to base a policy off
of. I also edited some parts to add the adjective off-topic to the
rules about sexual content because certain topics require discussion
of sexual issues. As well, I switched a few parts to use abuse instead
of harassment because it's shorter and more impactful and also because
of semantic satiation.

I think the biggest change was in:

<p>Harassment includes offensive verbal comments related to gender,
age, sexual orientation, disability, physical appearance, body size,
race, religion, sexual images in public spaces, deliberate
intimidation, stalking, following, harassing photography or recording,
sustained disruption of talks or other events, inappropriate physical
contact, and unwelcome sexual attention.</p>


where I removed a whole list of things that offensive verbal comments
could be about, reordered actions by approximate seriousness and added
a few types of things that harassment could be. I removed the list of
possible offensive topics because I felt that the list could never be
complete and that the actual topic itself is beside the point, the
reason why offensive comments are bad is not because they hurt
people's feelings but because the language is not intended to serve a
constructive purpose but only to hurt people and also because the
comments are off-topic for the conference.
