### PR TITLE
Link to the French translation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Current available translations (in alphabetical order):
 
 * Dutch [http://nl.confcodeofconduct.com](http://nl.confcodeofconduct.com)
 * English: [http://confcodeofconduct.com](http://confcodeofconduct.com)
+* French: [http://fr.confcodeofconduct.com](http://fr.confcodeofconduct.com)
 * German: [http://de.confcodeofconduct.com](http://de.confcodeofconduct.com)
 * Italian: [http://it.confcodeofconduct.com](http://it.confcodeofconduct.com)
 * Norwegian: [http://no.confcodeofconduct.com](http://no.confcodeofconduct.com)


### PR DESCRIPTION
I thought the French translation was missing entirely since it was not in the list. However, I saw it in the rest of the docs and found that it was actually there.