### PR TITLE
fix spelling error / verbeter spelfout

### DIFF
--- a/index-nl.html
+++ b/index-nl.html
@@ -5,17 +5,17 @@
 <title>Gedragcode voor conferenties</title>
 <link rel="icon" type="image/x-icon" href="//confcodeofconduct.com/favicon.ico" />
 <style>
-* { 
+* {
   font-family: 'helvetica neue', arial, helvetica;
   font-weight: 200;
 }
 
-body { 
+body {
   background: white;
   color: #212121;
   margin: 0;
   margin-top: 80px;
-} 
+}
 
 p, h1, h2 {
   max-width: 80%;
@@ -27,7 +27,7 @@ h1 {
   font-size: 38px;
 }
 
-h2 { 
+h2 {
   font-size: 28px;
   margin-top: 48px;
 }
@@ -89,7 +89,7 @@ em {
 <div class="footer">
 <p><small><em>Originele tekst: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a><br>
 
-Help ons met een vertaling of het verbeteringen van deze tekst: <a href="https://github.com/leftlogic/confcodeofconduct.com">http://github.com/leftlogic/confcodeofconduct.com</a><br>
+Help ons met een vertaling of het verbeteren van deze tekst: <a href="https://github.com/leftlogic/confcodeofconduct.com">http://github.com/leftlogic/confcodeofconduct.com</a><br>
 
 Op dit werk is de volgende licentie van toepassing <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a></em></small>
 


### PR DESCRIPTION
There is a Dutch spelling error in the text. See the commit for the change on line 92.

Er zit een taalfout in de Nederlandse vertaling. Zie de commit op regel 92.
