### PR TITLE
Added a CONTRIBUTING file to describe translation guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+* Changes made to the content should be made first to `index.html`.
+* Changes made to the HTML markup or other formatting should be made to all
+  index files.
+* Translations should be based off `index.html`.
+* Translations should be named `index-XX.html` where `XX` is the two letter
+  [ISO-639-1] language short code.
+
+[ISO-639-1]: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes


### PR DESCRIPTION
I assumed that `index.html` was the authoritative file that all translations are based off of, based on my experience with [www.ruby-lang.org](https://github.com/ruby/www.ruby-lang.org)'s translation guidelines.