### PR TITLE
Create an American English version

### DIFF
--- a/index-en-us.html
+++ b/index-en-us.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf8">
+<title>Conference Code of Conduct</title>
+<style>
+* {
+  font-family: 'helvetica neue', arial, helvetica;
+  font-weight: 200;
+}
+
+html {
+  background: #efefef;
+}
+
+body {
+  background: white;
+  color: #212121;
+  margin: 0;
+  padding-top: 60px;
+}
+
+p, h1, h2 {
+  max-width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h1 {
+  font-size: 38px;
+}
+
+h2 {
+  font-size: 28px;
+  margin-top: 48px;
+}
+
+p {
+  line-height: 24px;
+  font-size: 18px;
+  text-align: justify;
+}
+
+a {
+  color: blue;
+}
+
+em {
+  font-weight: 400;
+}
+
+.footer {
+  padding: 40px 0;
+  background: #efefef;
+  margin: 0;
+  margin-top: 40px;
+  max-width: 100%;
+}
+
+.footer p {
+  text-align: left;
+}
+</style>
+</head>
+<body>
+<h1>Conference Code of Conduct</h1>
+
+<p>All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organisers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
+
+<h2>Need Help?</h2>
+
+<p>You have our contact details in the emails we&#39;ve sent.</p>
+
+<h2>The Quick Version</h2>
+
+<p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
+
+<h2>The Less Quick Version</h2>
+
+<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+
+<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+
+<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.</p>
+
+<p>If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
+
+<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they&#39;ll be wearing branded t-shirts.</p>
+
+<p>Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
+
+<p>We expect participants to follow these rules at conference and workshop venues and conference-related social events.</p>
+
+<div class="footer">
+<p><small><em>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>
+
+Please help by translating or improving: <a href="https://github.com/leftlogic/confcodeofconduct.com">http://github.com/leftlogic/confcodeofconduct.com</a><br>
+
+This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a></em></small>
+
+</p>
+</div>


### PR DESCRIPTION
I assume that the index.html version was created by people who speak British English instead of American English. This translation uses the "-ized" suffix instead of "-ised" (i.e., "sexualized").