### PR TITLE
Recentering the code of conduct on all topics that may bring a bad experience to attendees

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -76,7 +76,7 @@ avons envoyés.</p>
 <p>Notre conférence se veut une expérience positive, notamment au regard de la loi.
   Nous ne tolérons aucun vol, dégradation, harcèlement, usage ou revente de drogue, 
   conduite en état d'ivresse, organisation de délit d'initié par rapport aux start-ups,
-  ou autres manquement à la loi. Ceci inclut les conférences, les ateliers, les
+  ou autres manquements à la loi. Ceci inclut les conférences, les ateliers, les
   soirées, Twitter et les autres médias en ligne. Les participants à la
   conférence qui violent ces règles peuvent être sanctionnés, voire exclus
   de la conférence <em>sans remboursement</em>, à la discrétion des
@@ -84,9 +84,9 @@ avons envoyés.</p>
 
 <h2>La version moins rapide</h2>
 
-<p>Le vol et la dégradation incluent les équipements et bâtiments présents sur le site de la conférence ou mis à disposition par les organisateurs hors du lieu de la  conférence. Ils incluent aussi les affaires du public de cette conférence et les affaires personnelles des organisateurs.</p>
+<p>Le vol et la dégradation incluent les équipements et bâtiments présents sur le site de la conférence ou mis à disposition par les organisateurs hors du lieu de la conférence. Ils incluent aussi les affaires du public de cette conférence et les affaires personnelles des organisateurs.</p>
 
-<p>Les intimidations délibérées, que ce soit en amont de la conférence, sur place ou a posteriori, et qu'elles soient à connotation sexuelle ou qu'elles concernent la vente illégale de billets, de substances illicites, sont interdites.</p>
+<p>Les intimidations délibérées, que ce soit en amont de la conférence, sur place ou a posteriori, et qu'elles soient à connotation sexuelle ou qu'elles concernent la vente illégale de billets ou de substances illicites, sont interdites.</p>
 
 <p>Les sponsors, les participants, les intervenants et les organisateurs s'engagent à remettre à la loi toute situation illégale dont ils sont témoins.<p>
 

--- a/index-fr.html
+++ b/index-fr.html
@@ -73,54 +73,30 @@ avons envoyés.</p>
 
 <h2>La version rapide</h2>
 
-<p>Notre conférence se veut une expérience sans harcèlement, quelque soit
-votre sexe, votre orientation sexuelle, votre handicap, votre apparence
-physique, votre poids, votre race ou votre religion. Nous ne tolérons aucun
-harcèlement des participants à la conférence, quelque soit sa forme. Les
-expressions et les images à connotation sexuelle ne sont pas appropriées lors
-de l'événement. Ceci inclut les conférences, les ateliers, les soirées, Twitter
-et les autres médias en ligne. Les participants à la conférence qui violent
-ces règles peuvent être sanctionnés, voire exclus de la conférence <em>sans
-remboursement</em>, à la discrétion des organisateurs de la conférence.</p>
+<p>Notre conférence se veut une expérience positive, notamment au regard de la loi.
+  Nous ne tolérons aucun vol, dégradation, harcèlement, usage ou revente de drogue, 
+  conduite en état d'ivresse, organisation de délit d'initié par rapport aux start-ups,
+  ou autres manquement à la loi. Ceci inclut les conférences, les ateliers, les
+  soirées, Twitter et les autres médias en ligne. Les participants à la
+  conférence qui violent ces règles peuvent être sanctionnés, voire exclus
+  de la conférence <em>sans remboursement</em>, à la discrétion des
+  organisateurs de la conférence.</p>
 
 <h2>La version moins rapide</h2>
 
-<p>Le harcèlement inclut des commentaires oraux sur le sexe, l'orientation
-sexuelle, le handicap, l'apparence physique, le poids, la race, la religion,
-les images à connotation sexuelle dans des lieux publics, les intimidations
-délibérées, la traque, la poursuite, un harcèlement photographique ou vidéo,
-une suite d'interruption des conférences et des autres événements, un contact
-physique inapproprié et des avances sexuelles non désirées.</p>
+<p>Le vol et la dégradation incluent les équipements et bâtiments présents sur le site de la conférence ou mis à disposition par les organisateurs hors du lieu de la  conférence. Ils incluent aussi les affaires du public de cette conférence et les affaires personnelles des organisateurs.</p>
 
-<p>Les participants à qui il sera demandé d'arrêter tout comportement de
-harcèlement doivent arrêter immédiatement.</p>
+<p>Les intimidations délibérées, que ce soit en amont de la conférence, sur place ou a posteriori, et qu'elles soient à connotation sexuelle ou qu'elles concernent la vente illégale de billets, de substances illicites, sont interdites.</p>
 
-<p>Les sponsors sont aussi sujet à la politique anti-harcèlement. En
-particulier, les sponsors ne doivent pas utiliser d'images ou de matériels à
-connotation sexuelle. Ils ne doivent pas non plus engager d'activités à
-connotation sexuelle. L'équipe du stand (y compris les volontaires) ne doivent
-pas utiliser de vêtements, uniformes ou costumes à connotation sexuelle. Ils ne
-doivent pas non plus créer un environnement sexualisé.</p>
+<p>Les sponsors, les participants, les intervenants et les organisateurs s'engagent à remettre à la loi toute situation illégale dont ils sont témoins.<p>
 
-<p>Si un participant a un comportement de harcèlement, les organisateurs de la
-conférence peuvent prendre toute action qui leur semble adéquate. Cela va d'un
-simple avertissement à l'exclusion du participant de la conférence sans
-remboursement.</p>
+<p>Si un participant a un comportement illégal, les organisateurs de la conférence peuvent prendre toute action qui leur semble adéquate. Cela va d'un simple avertissement à l'exclusion du participant de la conférence sans remboursement.</p>
 
-<p>Si vous vous sentez harcelé, si vous pensez que quelqu'un se fait harceler,
-et plus généralement en cas de problème, merci de contacter immédiatement un membre
-de l'organisation de l'événement. Les membres sont facilement identifiables à leur
-t-shirts aux couleurs de l'événement.</p>
+<p>Notamment, si vous vous sentez harcelé, si vous pensez que quelqu'un se fait harceler, et plus généralement en cas de problème, merci de contacter immédiatement un membre de l'organisation de l'événement. Les membres sont facilement identifiables à leur t-shirts aux couleurs de l'événement.</p>
 
-<p>Les membres de l'organisation seront ravis d'aider les participants à
-contacter la sécurité de l'hôtel ou du bâtiment où se déroule l'événement, ou
-les forces de l'ordre, à fournir une escorte ainsi qu'à aider de toute autre
-façon les personnes victimes de harcèlement, pour garantir leur sécurité pendant
-la durée de l'événement. Nous apprécions votre participation à l'événement.</p>
+<p>Les membres de l'organisation seront ravis d'aider les participants à contacter la sécurité de l'hôtel ou du bâtiment où se déroule l'événement, ou les forces de l'ordre, à fournir une escorte ainsi qu'à aider de toute autre façon les personnes victimes de harcèlement, pour garantir leur sérénité pendant la durée de l'événement. Nous apprécions votre participation à l'événement.</p>
 
-<p>Nous attendons des participants qu'ils suivent ces règles dans le bâtiment
-des conférences et des ateliers, ainsi que pendant les événements sociaux
-relatifs à la conférence.</p>
+<p>Nous attendons des participants qu'ils suivent ces règles dans le bâtiment des conférences et des ateliers, ainsi que pendant les événements sociaux relatifs à la conférence.</p>
 
 <div class="footer">
 <p><small><em>Version originale et crédit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>

--- a/index.html
+++ b/index.html
@@ -73,19 +73,19 @@ em {
 
 <h2>The Quick Version</h2>
 
-<p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
+<p>Our conference is dedicated to providing a positive experience, especially concerning the law. We do not tolerate theft, deterioration, harassment, use or resale of drugs, driving under influence, organization of insider trading against start-ups, or other breach of the law. This includes talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
 
 <h2>The Less Quick Version</h2>
 
-<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+<p>Theft and deterioration include the equipment and buildings at the site of the conference or made available by the organizers outside of this place. They also include the belongings of the audience, and private belongings of the organizers.</p>
 
-<p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+<p>Deliberate intimidation, be it before the conference, during or after, and whether or not it is sexual or about ticket sales or about illicit substances, is forbidden.</p>
 
-<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
+<p>Sponsors, participants, speakers and organizers all commit to notify law enforcement authorities any illicit situation they witness.</p>
 
 <p>If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
 
-<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they&#39;ll be wearing branded t-shirts.</p>
+<p>Notably, if you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they&#39;ll be wearing branded t-shirts.</p>
 
 <p>Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
 


### PR DESCRIPTION
This pull request refocusses the code of conduct on many topics that may bring a bad experience to attendees.

Don't get me wrong: Sexual harassment and discrimination must be condemned.

However, as a male, I feel stigmatized by the old version of the code of conduct. Let me explain.

I often come across media that depicts men as incapable, or pervert, or violent, or harassers, or thugs, and associates qualities such as intelligence or excellence in class to women. The old version of this code of conduct participates to this stigmatization. It is a stigmatization, because it negates the efforts of most people, who control their behavior in a non-violent way and who make more than all required efforts to bring equality to our society. So focussing too much on harassment maintains the stigma.

There are many other topics that could bring a bad experience in a conference. Let's not discriminate which problems we tackle.