### PR TITLE
Add VI[M] temporary files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .DS_Store
+.*.swp
+*~


### PR DESCRIPTION
Add temporary files created by the VI[M] editor to the `.gitignore`
file in order to make it easier to use this editor when working with
this repository.