### PR TITLE
Remove extra word

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -84,7 +84,7 @@ em {
 
 <p>El personal de la conferencia estará contento de ayudar a los participates a contactar con la seguridad del hotel/sala o con las autoridades locales, proveer escolta o asistir de otra manera a aquellos que estén sufriendo abusos para que se sientan seguros mientras dure la conferencia. Valoramos tu asistencia.</p>
 
-<p>Esperamos que los participantes sigan estas reglas en la la conferencia, talleres y eventos sociales relacionados con la conferencia.</p>
+<p>Esperamos que los participantes sigan estas reglas en la conferencia, talleres y eventos sociales relacionados con la conferencia.</p>
 
 <div class="footer">
 <p><small><em>Fuente original y créditos: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>


### PR DESCRIPTION
There was an extra `la` before `la conferencia` in the Spanish translation of the Code of Conduct.