### PR TITLE
Fixed typo: on github.com should read en github.com

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -102,7 +102,7 @@
 
             Por favor, ayuda traduciendo o mejorando:
             <a href="https://github.com/confcodeofconduct/confcodeofconduct.com"
-              >on github.com</a
+              >en github.com</a
             ><br />
 
             Este trabajo está licenciado bajo


### PR DESCRIPTION
in spanish **on github.com** should read **en github.com**

Hope it helps!