### PR TITLE
FR - gender inclusive writing, more actionable content

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -16,7 +16,7 @@
     <p>
       Toutes les personnes participant à la conférence,
       y compris sponsors et bénévoles
-      s'engagent à accepter le code d'éthique et de déontologie, ou "code de conduite" suivant.
+      s'engagent à accepter le code d'éthique et de déontologie, ou « code de conduite » suivant.
       L'organisation s'attachera à faire respecter ce code durant l'événement.
       Nous attendons la coopération de chacun‧e pour assurer un environnement sain pour tous.
     </p>

--- a/index-fr.html
+++ b/index-fr.html
@@ -24,7 +24,7 @@
     <div class="notice">
       <h2>Important</h2>
       <p>
-        Cette page est un modèle de code d'éthique et de déontologie (code de conduite) et
+        Cette page est un modèle de code d'éthique et de déontologie (« code de conduite ») et
         <strong>ne suffit pas pour en faire un code que l'on peut appliquer</strong>.
         Si un événement se contente d'un lien sur cette page, demandez-leur poliment
         de publier leur propre code, comprenant les informations de contact

--- a/index-fr.html
+++ b/index-fr.html
@@ -39,7 +39,7 @@
       votre sexe, votre identité sexuelle, votre âge, votre orientation
       sexuelle, votre handicap, votre apparence physique, votre poids, votre
       race ou votre religion. Nous ne tolérons aucun harcèlement des
-      participant·e·s à la conférence, sous quelque forme que ce soit.
+      participant‧e‧s à la conférence, sous quelque forme que ce soit.
       Les expressions et les images à connotation sexuelle ne sont pas appropriées
       lors de l'événement. Ceci inclut les conférences, les ateliers, les soirées,
       Twitter et les autres médias en ligne.
@@ -61,7 +61,7 @@
     </p>
 
     <p>
-      Les participant·e·s à qui il sera demandé d'arrêter tout comportement de
+      Les participant‧e‧s à qui il sera demandé d'arrêter tout comportement de
       harcèlement doivent arrêter immédiatement.
     </p>
 
@@ -81,7 +81,7 @@
     </p>
 
     <p>
-      Si vous vous sentez harcelé·e, si vous pensez que quelqu'un se fait
+      Si vous vous sentez harcelé‧e, si vous pensez que quelqu'un se fait
       harceler, et plus généralement en cas de problème, merci de contacter
       immédiatement l’équipe d’organisation de l'événement. L'organisation s'assure
       que ses membres sont facilement identifiables (badge, brassard, tour de cou,
@@ -89,7 +89,7 @@
     </p>
 
     <p>
-      Les membres de l'organisation seront ravi·e·s d'aider les participants à
+      Les membres de l'organisation seront ravi‧e‧s d'aider les participants à
       contacter la sécurité de l'hôtel ou du bâtiment où se déroule l'événement,
       ou les forces de l'ordre ; à fournir une escorte ainsi qu'à aider de toute
       autre façon les personnes victimes de harcèlement, pour garantir leur
@@ -98,7 +98,7 @@
     </p>
 
     <p>
-      Nous attendons de chacun·e le respect de ces règles dans le bâtiment
+      Nous attendons de chacun‧e le respect de ces règles dans le bâtiment
       des conférences et des ateliers, ainsi que pendant les événements sociaux
       relatifs à la conférence.
     </p>

--- a/index-fr.html
+++ b/index-fr.html
@@ -15,7 +15,7 @@
 
     <p>
       Toutes les personnes participant à la conférence,
-      y compris participant·e·s, orateurs·trices, sponsors et volontaires
+      y compris sponsors et bénévoles
       s'engagent à accepter le code d'éthique et de déontologie, ou "code de conduite" suivant.
       L'organisation s'attachera à faire respecter ce code durant l'événement.
       Nous attendons de la part de chacun·e leur coopération pour assurer un environnement sain pour tous.

--- a/index-fr.html
+++ b/index-fr.html
@@ -18,7 +18,7 @@
       y compris sponsors et bénévoles
       s'engagent à accepter le code d'éthique et de déontologie, ou "code de conduite" suivant.
       L'organisation s'attachera à faire respecter ce code durant l'événement.
-      Nous attendons de la part de chacun·e leur coopération pour assurer un environnement sain pour tous.
+      Nous attendons la coopération de chacun‧e pour assurer un environnement sain pour tous.
     </p>
 
     <div class="notice">

--- a/index-fr.html
+++ b/index-fr.html
@@ -76,7 +76,7 @@
 
     <p>
       Face à un comportement de harcèlement, l'équipe d'organisation de la conférence
-      peuvent prendre toute action qui leur semble adéquate.
+      peut prendre toute action qui lui semble adéquate.
       Cela va d'un simple avertissement à l'exclusion sans remboursement de la conférence.
     </p>
 

--- a/index-fr.html
+++ b/index-fr.html
@@ -75,7 +75,7 @@
     </p>
 
     <p>
-      Face à un comportement de harcèlement, les organisateurs de la conférence
+      Face à un comportement de harcèlement, l'équipe d'organisation de la conférence
       peuvent prendre toute action qui leur semble adéquate.
       Cela va d'un simple avertissement à l'exclusion sans remboursement de la conférence.
     </p>

--- a/index-fr.html
+++ b/index-fr.html
@@ -14,11 +14,11 @@
     <h1>Code de conduite pour la conférence</h1>
 
     <p>
-      Tous les participants, conférenciers, sponsors et volontaires pour notre
-      conférence doivent accepter le code de conduite suivant. Les organisateurs
-      s'attacheront à faire respecter ce code durant l'événement. Nous attendons
-      de la part de chaque participant une coopération pour assurer un
-      environnement sain pour tous.
+      Toutes les personnes participant à la conférence,
+      y compris participant·e·s, orateurs·trices, sponsors et volontaires
+      s'engagent à accepter le code d'éthique et de déontologie, ou "code de conduite" suivant.
+      L'organisation s'attachera à faire respecter ce code durant l'événement.
+      Nous attendons de la part de chacun·e leur coopération pour assurer un environnement sain pour tous.
     </p>
 
     <h2>La version rapide</h2>
@@ -28,66 +28,66 @@
       votre sexe, votre identité sexuelle, votre âge, votre orientation
       sexuelle, votre handicap, votre apparence physique, votre poids, votre
       race ou votre religion. Nous ne tolérons aucun harcèlement des
-      participants à la conférence, quel que soit sa forme. Les expressions et
-      les images à connotation sexuelle ne sont pas appropriées lors de
-      l'événement. Ceci inclut les conférences, les ateliers, les soirées,
-      Twitter et les autres médias en ligne. Les participants à la conférence
-      qui violent ces règles peuvent être sanctionnés, voire exclus de la
-      conférence <em>sans remboursement</em>, à la discrétion des organisateurs
-      de la conférence.
+      participant·e·s à la conférence, sous quelque forme que ce soit.
+      Les expressions et les images à connotation sexuelle ne sont pas appropriées
+      lors de l'événement. Ceci inclut les conférences, les ateliers, les soirées,
+      Twitter et les autres médias en ligne.
+      L'organisation s'engage à prendre des sanctions appropriées pour les personnes
+      qui violent ces règles, jusqu'à l'exclusion <em>sans remboursement</em>
+      et le recours légal.
     </p>
 
     <h2>La version moins rapide</h2>
 
     <p>
-      Le harcèlement inclut des commentaires oraux sur le sexe, l'identité
-      sexuelle, l'âge, l'orientation sexuelle, le handicap, l'apparence
+      Le harcèlement inclut des commentaires à l'oral ou à l'écrit sur le sexe,
+      l'identité sexuelle, l'âge, l'orientation sexuelle, le handicap, l'apparence
       physique, le poids, la race, la religion, les images à connotation
       sexuelle dans des lieux publics, les intimidations délibérées, la traque,
       la poursuite, un harcèlement photographique ou vidéo, une suite
-      d'interruption des conférences et des autres événements, un contact
+      d'interruptions des conférences et des autres événements, un contact
       physique inapproprié et des avances sexuelles non désirées.
     </p>
 
     <p>
-      Les participants à qui il sera demandé d'arrêter tout comportement de
+      Les participant·e·s à qui il sera demandé d'arrêter tout comportement de
       harcèlement doivent arrêter immédiatement.
     </p>
 
     <p>
       Les sponsors sont aussi sujet à la politique anti-harcèlement. En
-      particulier, les sponsors ne doivent pas utiliser d'images ou de matériels
-      à connotation sexuelle. Ils ne doivent pas non plus engager d'activités à
-      connotation sexuelle. L'équipe du stand (y compris les volontaires) ne
-      doivent pas utiliser de vêtements, uniformes ou costumes à connotation
+      particulier, les sponsors ne doivent pas utiliser d'images ou de supports
+      à connotation sexuelle. Ils ne doivent pas non plus se livrer à des activités
+      à connotation sexuelle. L'équipe du stand (y compris les volontaires) ne
+      doit pas utiliser de vêtements, uniformes ou costumes à connotation
       sexuelle. Ils ne doivent pas non plus créer un environnement sexualisé.
     </p>
 
     <p>
-      Si un participant a un comportement de harcèlement, les organisateurs de
-      la conférence peuvent prendre toute action qui leur semble adéquate. Cela
-      va d'un simple avertissement à l'exclusion du participant de la conférence
-      sans remboursement.
+      Face à un comportement de harcèlement, les organisateurs de la conférence
+      peuvent prendre toute action qui leur semble adéquate.
+      Cela va d'un simple avertissement à l'exclusion sans remboursement de la conférence.
     </p>
 
     <p>
-      Si vous vous sentez harcelé, si vous pensez que quelqu'un se fait
+      Si vous vous sentez harcelé·e, si vous pensez que quelqu'un se fait
       harceler, et plus généralement en cas de problème, merci de contacter
-      immédiatement un membre de l'organisation de l'événement. Les membres sont
-      facilement identifiables à leur t-shirts aux couleurs de l'événement.
+      immédiatement l'organisation de l'événement. L'organisation s'assure
+      que ses membres sont facilement identifiables (badge, brassard, tour de cou,
+        t-shirt...) présentés au début de la conférence.
     </p>
 
     <p>
-      Les membres de l'organisation seront ravis d'aider les participants à
+      Les membres de l'organisation seront ravi·e·s d'aider les participants à
       contacter la sécurité de l'hôtel ou du bâtiment où se déroule l'événement,
-      ou les forces de l'ordre, à fournir une escorte ainsi qu'à aider de toute
+      ou les forces de l'ordre ; à fournir une escorte ainsi qu'à aider de toute
       autre façon les personnes victimes de harcèlement, pour garantir leur
       sécurité pendant la durée de l'événement. Nous apprécions votre
       participation à l'événement.
     </p>
 
     <p>
-      Nous attendons des participants qu'ils suivent ces règles dans le bâtiment
+      Nous attendons de chacun·e le respect de ces règles dans le bâtiment
       des conférences et des ateliers, ainsi que pendant les événements sociaux
       relatifs à la conférence.
     </p>

--- a/index-fr.html
+++ b/index-fr.html
@@ -83,7 +83,7 @@
     <p>
       Si vous vous sentez harcelé·e, si vous pensez que quelqu'un se fait
       harceler, et plus généralement en cas de problème, merci de contacter
-      immédiatement l'organisation de l'événement. L'organisation s'assure
+      immédiatement l’équipe d’organisation de l'événement. L'organisation s'assure
       que ses membres sont facilement identifiables (badge, brassard, tour de cou,
         t-shirt...) présentés au début de la conférence.
     </p>

--- a/index-fr.html
+++ b/index-fr.html
@@ -85,7 +85,7 @@
       harceler, et plus généralement en cas de problème, merci de contacter
       immédiatement l’équipe d’organisation de l'événement. L'organisation s'assure
       que ses membres sont facilement identifiables (badge, brassard, tour de cou,
-        t-shirt...) présentés au début de la conférence.
+        t-shirt…) présentés au début de la conférence.
     </p>
 
     <p>

--- a/index-fr.html
+++ b/index-fr.html
@@ -21,6 +21,17 @@
       Nous attendons de la part de chacun·e leur coopération pour assurer un environnement sain pour tous.
     </p>
 
+    <div class="notice">
+      <h2>Important</h2>
+      <p>
+        Cette page est un modèle de code d'éthique et de déontologie (code de conduite) et
+        <strong>ne suffit pas pour en faire un code que l'on peut appliquer</strong>.
+        Si un événement se contente d'un lien sur cette page, demandez-leur poliment
+        de publier leur propre code, comprenant les informations de contact
+        pour remonter les problèmes ou trouver du soutien.
+      </p>
+    </div>
+
     <h2>La version rapide</h2>
 
     <p>

--- a/index-fr.html
+++ b/index-fr.html
@@ -69,7 +69,7 @@
       Les sponsors sont aussi sujet à la politique anti-harcèlement. En
       particulier, les sponsors ne doivent pas utiliser d'images ou de supports
       à connotation sexuelle. Ils ne doivent pas non plus se livrer à des activités
-      à connotation sexuelle. L'équipe du stand (y compris les volontaires) ne
+      à connotation sexuelle. L'équipe du stand (y compris les bénévoles) ne
       doit pas utiliser de vêtements, uniformes ou costumes à connotation
       sexuelle. Ils ne doivent pas non plus créer un environnement sexualisé.
     </p>


### PR DESCRIPTION
1. used genderless or gender-inclusive writing
   1a. changed sentences to avoid gendered french names or adjectives
   1b. when I could not do that, I added both forms (participant·e·s or orateurs·trices)
2. changed some anglicisms
   2a. Code of Conduct (code de conduite -> Code d'Éthique et de Déontologie) just once
   2b. materials (matériaux -> supports)
3. made things more explicit and actionable
   3a. oral comments -> oral or written comments
   3b. sanctions -> up to exclusion and legal action (already mentioned later in the document)
   3c. organisers only wear colored t-shirts -> they can have badges, armbands, lanyards...)

Concerning 3a &3b, I felt that:
- someone could say "my comment was made on Facebook, not orally".
- "from warnings to exclusion" -> anything they deem appropriate, up to exclusion and legal action
- contacting security and escorting -> it was unclear if organisers can just ask security to do it, or commit to doing it themselves if  no other solution can be found.

If anything, the slight changes in meaning here are demanding more commitment from the organisers.