### PR TITLE
feat: translate notice into german

### DIFF
--- a/index-de.html
+++ b/index-de.html
@@ -21,6 +21,17 @@
       einem sicheren und angenehmen Ort für alle zu machen.
     </p>
 
+    <div class="notice">
+      <h2>Wichtiger Hinweis</h2>
+      <p>
+        Diese Verhaltensregeln sind eine Vorlage und
+        <strong>sollten nicht als verbindlich angesehen werden</strong>. Sollte
+        eine Veranstaltung auf diese Seite verlinkt haben, bitte sie darum, ihre
+        eigenen Verhaltensregeln zu veröffentlichen, inklusive Details, wie
+        Probleme gemeldet werden sollen und wo Unterstützung zu finden ist.
+      </p>
+    </div>
+
     <h2>Die Kurzfassung</h2>
 
     <p>
@@ -110,7 +121,7 @@
 
             Bitte helft beim Übersetzen und Verbessern dieser Regeln:
             <a href="https://github.com/confcodeofconduct/confcodeofconduct.com"
-              >on github.com</a
+              >auf github.com</a
             ><br />
 
             Dieses Werk steht unter der


### PR DESCRIPTION
The german variante was missing the notice, so I added it and translated it. In the footer I also made a small change that was previously forgotten by a translater. It said "on github", instead of "auf github".