### PR TITLE
fix: link to cc license redirects to 404 not found

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
             This work is licensed under a
             <a
               rel="license"
-              href="http://creativecommons.org/licenses/by/3.0/deed.en"
+              href="https://creativecommons.org/licenses/by/3.0/deed.en"
               >Creative Commons Attribution 3.0 Unported License</a
             ></em
           ></small

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
             This work is licensed under a
             <a
               rel="license"
-              href="http://creativecommons.org/licenses/by/3.0/deed.en_US"
+              href="http://creativecommons.org/licenses/by/3.0/deed.en"
               >Creative Commons Attribution 3.0 Unported License</a
             ></em
           ></small


### PR DESCRIPTION
The current URL in the english version that links to the creative commons page, redirects to a 404 Not Found page, I updated the URL, so it links to the english version.